### PR TITLE
tweak build.sbt to provide a 'sbt spark/console' target that brings up spark REPL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,17 +8,19 @@ val SPARK_VERSION = "1.4.0"
 
 scalaVersion := "2.10.4"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % SPARK_VERSION % "provided"
+def commonSettings = Seq(
+  libraryDependencies ++= Seq(
+    "org.apache.spark" %% "spark-core" % SPARK_VERSION % "provided",
+    "org.apache.spark" %% "spark-sql" % SPARK_VERSION % "provided",
+    "org.apache.spark" %% "spark-mllib" % SPARK_VERSION % "provided",
+    "joda-time" % "joda-time" % "2.7", 
+    "org.joda" % "joda-convert" % "1.7",
+    "org.scalatest" %% "scalatest" % "2.2.4" % Test,
+    "org.json4s" %% "json4s-jackson" % "3.2.10" % "provided"
+  )
+)
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % SPARK_VERSION % "provided"
-
-libraryDependencies += "org.apache.spark" %% "spark-mllib" % SPARK_VERSION % "provided"
-
-libraryDependencies ++= Seq("joda-time" % "joda-time" % "2.7", "org.joda" % "joda-convert" % "1.7")
-
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % Test
-
-libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.10" % "provided"
+seq(commonSettings:_*)
 
 seq(bintraySettings:_*)
 
@@ -41,3 +43,20 @@ site.jekyllSupport()
 ghpages.settings
 
 git.remoteRepo := "git@github.com:willb/silex.git"
+
+lazy val silex = project in file(".")
+
+lazy val spark = project.dependsOn(silex)
+  .settings(commonSettings:_*)
+  .settings(
+    name := "spark",
+    initialCommands in console := """
+      |import org.apache.spark.SparkConf
+      |import org.apache.spark.SparkContext
+      |import org.apache.spark.SparkContext._
+      |import org.apache.spark.rdd.RDD
+      |val app = new com.redhat.et.silex.app.ConsoleApp()
+      |val spark = app.context
+      |com.redhat.et.silex.util.logging.consoleLogWarn
+    """.stripMargin,
+    cleanupCommands in console := "spark.stop")

--- a/src/main/scala/com/redhat/et/silex/util/logging.scala
+++ b/src/main/scala/com/redhat/et/silex/util/logging.scala
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the "silex" library of helpers for Apache Spark.
+ *
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.c
+ */
+
+package com.redhat.et.silex.util
+
+object logging {
+  import org.apache.log4j.{Logger, ConsoleAppender, Level}
+
+  private def consoleAppender =
+    Logger.getRootLogger().getAppender("console").asInstanceOf[ConsoleAppender]
+
+  def consoleLogLevel(lev: Level) { consoleAppender.setThreshold(lev) }
+  def consoleLogInfo { consoleLogLevel(Level.INFO) }
+  def consoleLogWarn { consoleLogLevel(Level.WARN) }
+  def consoleLogError { consoleLogLevel(Level.ERROR) }
+}
+


### PR DESCRIPTION
So you can say `sbt spark/console` and get a REPL with a local spark sandbox running, with all of the silex libs available, etc.
