### PR TITLE
Update Spark dependency to 1.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.redhat.et"
 
 version := "0.0.7"
 
-val SPARK_VERSION = "1.4.0"
+val SPARK_VERSION = "1.5.0"
 
 scalaVersion := "2.10.4"
 

--- a/src/main/scala/com/redhat/et/silex/app/app.scala
+++ b/src/main/scala/com/redhat/et/silex/app/app.scala
@@ -40,7 +40,7 @@ trait AppCommon {
     val initialConf = new SparkConf()
      .setAppName(appName)
      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-     .set("spark.kryoserializer.buffer.mb", "16")
+     .set("spark.kryoserializer.buffer", "16mb")
 
     configHooks.reverse.foldLeft(initialConf) {(c, f) => f(c)}
   }
@@ -122,7 +122,7 @@ private [silex] class TestConsoleApp(val suppliedMaster: String = "local[2]") ex
   override def master = suppliedMaster
   override def appName = "console"
   
-  addConfig( {(conf: SparkConf) => conf.set("spark.kryoserializer.buffer.mb", "2")})
+  addConfig( {(conf: SparkConf) => conf.set("spark.kryoserializer.buffer", "2mb")})
   
   def appMain(args: Array[String]) {
     // this never runs


### PR DESCRIPTION
This pull request updates Silex's Spark dependency to version 1.5.0 and fixes a deprecation warning in the default `AppCommon` configuration.
