### PR TITLE
Support for loading a directory of serialized data frames

### DIFF
--- a/src/main/scala/com/redhat/et/silex/frame/frameDir.scala
+++ b/src/main/scala/com/redhat/et/silex/frame/frameDir.scala
@@ -20,10 +20,13 @@ package com.redhat.et.silex.frame
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
+
+/** Module holding a utility function to load a directory of serialized data frames (e.g., Parquet files) */
 object FrameDir {
   import com.redhat.et.silex.util.DirUtils.readdir
   
-  def loadDir(sqlc: SQLContext, dir: String, repartition: Int = 0): DataFrame = {
+  /** Loads a directory of serialized data frames (e.g., Parquet files).  Returns a frame that is the union of the results of loading every file in <tt>dir</tt> */
+  def loadDir(sqlc: SQLContext, dir: String): DataFrame = {
     readdir(dir) map {file => sqlc.read.load(file)} reduce ((a, b) => a.unionAll(b))
   }
 }

--- a/src/main/scala/com/redhat/et/silex/frame/frameDir.scala
+++ b/src/main/scala/com/redhat/et/silex/frame/frameDir.scala
@@ -20,10 +20,10 @@ package com.redhat.et.silex.frame
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
-object ParquetDir {
+object FrameDir {
   import com.redhat.et.silex.util.DirUtils.readdir
   
-  def loadParquetDir(sqlc: SQLContext, dir: String, repartition: Int = 0): DataFrame = {
+  def loadDir(sqlc: SQLContext, dir: String, repartition: Int = 0): DataFrame = {
     readdir(dir) map {file => sqlc.read.load(file)} reduce ((a, b) => a.unionAll(b))
   }
 }

--- a/src/main/scala/com/redhat/et/silex/frame/parquetDir.scala
+++ b/src/main/scala/com/redhat/et/silex/frame/parquetDir.scala
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the "silex" library of helpers for Apache Spark.
+ *
+ * Copyright (c) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.et.silex.frame
+
+import org.apache.spark.sql.{DataFrame, SQLContext}
+
+object ParquetDir {
+  import com.redhat.et.silex.util.DirUtils.readdir
+  
+  def loadParquetDir(sqlc: SQLContext, dir: String, repartition: Int = 0): DataFrame = {
+    readdir(dir) map {file => sqlc.read.load(file)} reduce ((a, b) => a.unionAll(b))
+  }
+}
+

--- a/src/main/scala/com/redhat/et/silex/util/dirutils.scala
+++ b/src/main/scala/com/redhat/et/silex/util/dirutils.scala
@@ -23,9 +23,13 @@ object DirUtils {
   
   def maybeReaddir(dirname: String, flt: String => Boolean = (_ => true)): Option[Array[String]] = {
     val dirOption = Try(new java.io.File(dirname).getCanonicalFile).toOption
-    dirOption 
-      .filter { dir => dir.exists && dir.isDirectory } 
+    dirOption
+      .filter { dir => dir.exists && dir.isDirectory }
       .map { dir => dir.listFiles collect { case (file) if flt(file.getName) => file.getCanonicalPath } }
+  }
+  
+  def readdir(dirname: String, flt: String => Boolean = (_ => true)): Array[String] = {
+    maybeReaddir(dirname, flt).getOrElse(Array())
   }
 }
 

--- a/src/main/scala/com/redhat/et/silex/util/dirutils.scala
+++ b/src/main/scala/com/redhat/et/silex/util/dirutils.scala
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the "silex" library of helpers for Apache Spark.
+ *
+ * Copyright (c) 2014, 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.et.silex.util
+
+object DirUtils {
+  import scala.util.Try
+  
+  def maybeReaddir(dirname: String, flt: String => Boolean = (_ => true)): Option[Array[String]] = {
+    val dirOption = Try(new java.io.File(dirname).getCanonicalFile).toOption
+    dirOption 
+      .filter { dir => dir.exists && dir.isDirectory } 
+      .map { dir => dir.listFiles collect { case (file) if flt(file.getName) => file.getCanonicalPath } }
+  }
+}
+

--- a/src/test/scala/com/redhat/et/silex/frame/frameDirSuite.scala
+++ b/src/test/scala/com/redhat/et/silex/frame/frameDirSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the "silex" library of helpers for Apache Spark.
+ *
+ * Copyright (c) 2015 Red Hat, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.et.silex.frame
+
+import com.redhat.et.silex.testing.{PerTestSparkContext, TempDirFixtures}
+
+import org.scalatest._
+
+case class NumberBox(i: Int) {}
+
+class FrameDirSpec extends FlatSpec with Matchers with TempDirFixtures with PerTestSparkContext {
+  import org.apache.spark.sql.Row
+  
+  it should "successfully load the right number of records from a directory of Parquet files" in {
+    val sqlc = sqlContext
+    import sqlc.implicits._
+    
+    val frames = (1 to 10) map { i => (i, context.parallelize((1 to 100) map {j => NumberBox(i * j)}).toDF) }
+    frames foreach { case (id, frame) =>
+      frame.write.parquet("%s/test%d.parquet".format(tempPath, id))
+    }
+    
+    val union = frames map { case (_, frame) => frame } reduce { (l, r) => l unionAll r }
+    val loaded = FrameDir.loadDir(sqlc, tempPath)
+    
+    assert(union.count() == loaded.count())
+    assert(union.distinct().join(loaded.distinct(), loaded("i") === union("i")).count() == loaded.distinct().count())
+  }
+}

--- a/src/test/scala/com/redhat/et/silex/testing/dirFixtures.scala
+++ b/src/test/scala/com/redhat/et/silex/testing/dirFixtures.scala
@@ -29,8 +29,8 @@ import Files.{isSymbolicLink, createTempDirectory, deleteIfExists}
 trait TempDirFixtures extends AbstractBeforeAndAfter {
   self: BeforeAndAfterEach with Suite =>
   
-  private var tempDir: Option[File] = None
-  private def tempPath: String = tempDir.map { _.toString }.get
+  protected var tempDir: Option[File] = None
+  protected def tempPath: String = tempDir.map { _.toString }.get
 
   private [this] def cleanUp(path: File) {
     if (path.isDirectory() && !isSymbolicLink(path.toPath)) {


### PR DESCRIPTION
This commit adds a utility function to load a directory of serialized data frames (e.g., Parquet files) and return their union as a single frame.
