### PR TITLE
document interactive use

### DIFF
--- a/src/jekyll/index.md
+++ b/src/jekyll/index.md
@@ -1,9 +1,11 @@
 ---
 layout: default
-title:
+title: Silex
 ---
 
 [silex](https://github.com/radanalyticsio/silex) is a library of reusable code for Spark applications, factored out of applications we've built at Red Hat.  It will grow in the future but for now we have an application skeleton, some added functionality for data frames, and a histogramming RDD.  [Pull requests](https://github.com/radanalyticsio/silex/pulls) and [issue reports](https://github.com/radanalyticsio/silex/issues) are welcome!
+
+You can use Silex [in your own Scala projects](/coordinates/) or [interactively](/interactive).
 
 ### Recent news
 

--- a/src/jekyll/interactive.md
+++ b/src/jekyll/interactive.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Using Silex interactively
+permalink: interactive/
+---
+
+It's possible to try out Silex interactively without building a project.  You have two options:  you can use `spark-shell` if you have Spark installed, or you can use `sbt console` from a checkout of the source repository.
+
+### Using a Spark shell
+
+You can run Silex under a Spark shell without explicitly downloading it.  Here's the invocation to make it work:
+
+{% highlight bash %}
+spark-shell --repositories https://dl.bintray.com/willb/maven/ --packages io.radanalytics:silex_2.11:{{ site.silexVersion }}
+{% endhighlight %}
+
+(Thanks to [Jirka Kremser](https://plus.google.com/+JiriKremser) for this suggestion!)
+
+### Using the developer console
+
+If you've checked out the [Silex repository](https://github.com/radanalyticsio/silex), you can run `sbt console` and get an environment with Silex preloaded.  
+
+(In general, you can [customize the behavior of `sbt console`](https://chapeau.freevariable.com/2014/09/interactive-sbt.html).)


### PR DESCRIPTION
This PR shows how to use Silex from the sbt console or from a Spark shell.

Thanks to @Jiri-Kremser for the suggestion (and for documenting how to run Silex from a Spark shell).

Fixes #72.