### PR TITLE
Replace hosted mint with Google Analytics.

### DIFF
--- a/src/jekyll/_includes/themes/bootstrap/default.html
+++ b/src/jekyll/_includes/themes/bootstrap/default.html
@@ -17,8 +17,16 @@
 
     <link href="{{ BASE_PATH }}{{ site.JB.atom_path }}" type="application/atom+xml" rel="alternate" title="Sitewide ATOM Feed">
     <link href="{{ BASE_PATH }}{{ site.JB.rss_path }}" type="application/rss+xml" rel="alternate" title="Sitewide RSS Feed">
-    <script src="http://freevariable.com/mint/?js" type="text/javascript"></script>
-    
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-94133700-1', 'auto');
+      ga('send', 'pageview');
+
+    </script>    
   </head>
 
   <body>


### PR DESCRIPTION
The hosted mint statistics were appropriate when Silex was hosted
at freevariable.com.  This commit changes the template to use
the same Google Analytics setup as radanalytics.io.

Fixes #74, indirectly.